### PR TITLE
leveldb_manager: remove obsolete live upgrade compat code

### DIFF
--- a/src/leveldb_manager.erl
+++ b/src/leveldb_manager.erl
@@ -83,7 +83,6 @@
         , close/1]).
 
 %% private entry point (supervisor callback)
--export([ start_link/4]). % obsolete, upgrade compat
 -export([ start_link/3]).
 
 %% private entry points (gen_server callbacks)
@@ -147,9 +146,6 @@ default_options() ->
 open(Name, Path, Options) ->
   {ok, _Pid} = leveldb_manager_sup:start_manager(Name, Path, Options),
   {ok, Name}.
-
-start_link(_EtsOwner, Name, Path, Options) -> % obsolete, upgrade compat
-  start_link(Name, Path, Options).
 
 start_link(Name, Path, Options) ->
   %% Note: this function executes in the context of the supervisor,

--- a/src/leveldb_manager_sup.erl
+++ b/src/leveldb_manager_sup.erl
@@ -30,9 +30,6 @@
 %% private entry points (supervisor callbacks)
 -export([init/1]).
 
-%% obsolete, remove when all nodes have been restarted
--export([ets_owner/0]).
-
 %%%----------------------------------------------------------------
 
 start_link() ->
@@ -46,16 +43,6 @@ init([]) ->
          , 5000
          , worker
          , [leveldb_manager]}]}}.
-
-%% This code must remain until all nodes have been restarted and
-%% no process is executing in it.  Crashing an ets_owner process
-%% destroys the leveldb manager states it owns, crashes the supervisor,
-%% and kills the application.
-ets_owner() ->
-  %% We want this to block until any message arrives or five
-  %% minutes have passed, whichever occurs first.
-  receive _ -> ok after 5*60*1000 -> ok end,
-  ?MODULE:ets_owner().
 
 start_manager(Name, Path, Options) ->
   %% Clients call leveldb_manager:open/3 to create leveldb instances.


### PR DESCRIPTION
Remove obsolete code that was only there to provide live upgrade compatibility.
