### PR TITLE
Api fixes

### DIFF
--- a/src/leveldb_manager_sup.erl
+++ b/src/leveldb_manager_sup.erl
@@ -45,7 +45,7 @@ init([]) ->
          , [leveldb_manager]}]}}.
 
 start_manager(Name, Path, Options) ->
-  %% Clients call leveldb_manager:open/3 to create leveldb instances.
+  %% Clients call leveldb_manager:start/3 to create leveldb instances.
   %% That in turn calls this function, which uses the supervisor framework
   %% to call leveldb_manager:start_link/4 (see init/1 above) to create
   %% a new gen_server and link that to this supervisor.

--- a/src/leveldb_manager_sup.erl
+++ b/src/leveldb_manager_sup.erl
@@ -47,7 +47,7 @@ init([]) ->
 start_manager(Name, Path, Options) ->
   %% Clients call leveldb_manager:start/3 to create leveldb instances.
   %% That in turn calls this function, which uses the supervisor framework
-  %% to call leveldb_manager:start_link/4 (see init/1 above) to create
+  %% to call leveldb_manager:start_link/3 (see init/1 above) to create
   %% a new gen_server and link that to this supervisor.
   {ok, _Pid} = supervisor:start_child(?MODULE, [Name, Path, Options]).
 


### PR DESCRIPTION
Merge recent fixes from internal repo to make the API more compatible with eleveldb.
Merge start_link reference fix from internal repo.

Remaining diffs are due to whitespace [internal repo needs untabify] and the error logging mechanism.
