### PR TITLE
Store read lock holders under separate ETS keys

### DIFF
--- a/src/leveldb_manager.erl
+++ b/src/leveldb_manager.erl
@@ -276,6 +276,7 @@ state_set_handle(Name, Handle) -> ets:insert(Name, {handle, Handle}), Name.
 state_set_path(Name, Path) -> ets:insert(Name, {path, Path}), Name.
 
 state_add_reader(Name, Reader) -> ets:insert(Name, Reader), Name.
+
 state_try_remove_reader(Name, RPid) ->
   case ets:lookup(Name, RPid) of
     [{RPid, MonRef}] ->
@@ -284,6 +285,7 @@ state_try_remove_reader(Name, RPid) ->
     [] ->
       false
   end.
+
 state_has_readers(Name) ->
   ets:info(Name, size) > ?nr_static_keys.
 


### PR DESCRIPTION
The old way of storing all read lock holders in a list meant releasing a lock was an _O(n)_ operation. From now on the locks are stored as separate objects in the ETS (hash)table, so lookup and delete operations will become _O(1)_. This has a significant impact when there are many locks in the system.
